### PR TITLE
Preserve precision in Solana balance formatting

### DIFF
--- a/src/tokens/__tests__/solana.test.ts
+++ b/src/tokens/__tests__/solana.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { formatSolanaUnits } from '../solana.js';
+
+describe('formatSolanaUnits', () => {
+  it('formats balances without converting through Number', () => {
+    expect(formatSolanaUnits(1234567890123456789012345n, 6)).toBe(
+      '1234567890123456789.012345'
+    );
+  });
+
+  it('trims trailing fractional zeros', () => {
+    expect(formatSolanaUnits(1500000n, 6)).toBe('1.5');
+    expect(formatSolanaUnits(1000000n, 6)).toBe('1');
+  });
+
+  it('preserves small fractional balances', () => {
+    expect(formatSolanaUnits(1n, 9)).toBe('0.000000001');
+  });
+});

--- a/src/tokens/solana.ts
+++ b/src/tokens/solana.ts
@@ -77,6 +77,19 @@ export const SOLANA_TOKEN_DECIMALS: Record<SolanaTokenSymbol, number> = {
 
 const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
 
+export function formatSolanaUnits(rawAmount: bigint, decimals: number): string {
+  const divisor = 10n ** BigInt(decimals);
+  const whole = rawAmount / divisor;
+  const fraction = rawAmount % divisor;
+
+  if (decimals === 0 || fraction === 0n) {
+    return whole.toString();
+  }
+
+  const fractionStr = fraction.toString().padStart(decimals, '0').replace(/0+$/, '');
+  return `${whole}.${fractionStr}`;
+}
+
 function base58Decode(str: string): Uint8Array {
   const bytes: number[] = [0];
   for (const char of str) {
@@ -271,7 +284,7 @@ export class SolanaWallet {
       // Token account doesn't exist — balance is 0
     }
 
-    const humanBalance = (Number(rawBalance) / 10 ** decimals).toFixed(decimals).replace(/\.?0+$/, '') || '0';
+    const humanBalance = formatSolanaUnits(rawBalance, decimals);
 
     return { mint: mintAddress, rawBalance, humanBalance, decimals };
   }


### PR DESCRIPTION
getSplTokenBalance converted raw SPL balances through Number before formatting them. Large raw balances can lose precision and return rounded human balances.\n\nThis adds bigint based formatting for Solana token units and covers large, trimmed, and small fractional balances.